### PR TITLE
Suggested changes to Timer Bloc

### DIFF
--- a/lib/bloc/timer/timer_bloc.dart
+++ b/lib/bloc/timer/timer_bloc.dart
@@ -12,10 +12,6 @@ import 'package:tyme/utils/logger.dart';
 import 'package:tyme/utils/real_timer.dart';
 import 'package:wakelock/wakelock.dart';
 
-import '../../model/exercise.dart';
-import 'timer_event.dart';
-import 'timer_event.dart';
-
 class TimerBloc extends Bloc<TimerEvent, TimerState> with LoggerMixin {
   final Duration _initialSetupDuration;
 

--- a/lib/bloc/timer/timer_event.dart
+++ b/lib/bloc/timer/timer_event.dart
@@ -5,11 +5,7 @@ part 'timer_event.freezed.dart';
 
 @freezed
 abstract class TimerEvent with _$TimerEvent {
-  const factory TimerEvent.setupTick() = SetupTick;
-
-  const factory TimerEvent.runningTick() = RunningTick;
-
-  const factory TimerEvent.recoverTick() = RecoverTick;
+  const factory TimerEvent.ticked() = TimerTicked;
 
   const factory TimerEvent.pause() = Pause;
 


### PR DESCRIPTION
I like handling these sorts of externally triggered events as dumb as possible.
Meaning I simply want external sources to `add` an event, with whatever data I need.
In this case, we do not need any data, so we can simply add a `ticked` event.
Then our bloc will have to figure out what sort of states to yield, based on that event.

I also removed `_remaining` from the bloc, as you already keep it in the `State`, and it is a stateful thing.
It is fine to keep `_initial` as it is used to configure your bloc.